### PR TITLE
Attempt to fix config panel's handling of PHP

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -56,12 +56,22 @@ ynh_app_config_apply() {
 
     if [ "${changed[phpversion]}" == "true" ] && [ "$phpversion" == "none" ]
     then
-        # FIXME: This miserably fails because the setting phpversion get his 
-        # new value before ynh_app_config_apply gets called, so 
-        # ynh_remove_fpm_config try to remove the new not-yet-existent version.
+        ynh_app_setting_set --app=$app --key=phpversion --value=$old_phpversion
+        ynh_print_info --message="Removing PHP dependency..."
         ynh_remove_fpm_config
+        ynh_remove_app_dependencies
+        ynh_app_setting_delete --app=$app --key=phpversion
     elif [ "${changed[phpversion]}" == "true" ]
     then
+        new_phpversion=$phpversion
+        ynh_app_setting_set --app=$app --key=phpversion --value=$old_phpversion
+        ynh_print_info --message="Removing old PHP dependency..."
+        ynh_remove_fpm_config
+        ynh_remove_app_dependencies
+        ynh_print_info --message="Adding new PHP dependency..."
+        declare -g "phpversion"="$new_phpversion"
+        ynh_app_setting_set --app=$app --key=phpversion --value=$phpversion
+        ynh_install_app_dependencies "php${phpversion}-fpm"
         ynh_add_fpm_config --usage=low --footprint=low --phpversion=$phpversion
     fi
 

--- a/scripts/config
+++ b/scripts/config
@@ -59,7 +59,6 @@ ynh_app_config_apply() {
         ynh_app_setting_set --app=$app --key=phpversion --value=$old_phpversion
         ynh_print_info --message="Removing PHP dependency..."
         ynh_remove_fpm_config
-        ynh_remove_app_dependencies
         ynh_app_setting_delete --app=$app --key=phpversion
     elif [ "${changed[phpversion]}" == "true" ]
     then
@@ -67,7 +66,6 @@ ynh_app_config_apply() {
         ynh_app_setting_set --app=$app --key=phpversion --value=$old_phpversion
         ynh_print_info --message="Removing old PHP dependency..."
         ynh_remove_fpm_config
-        ynh_remove_app_dependencies
         ynh_print_info --message="Adding new PHP dependency..."
         declare -g "phpversion"="$new_phpversion"
         ynh_app_setting_set --app=$app --key=phpversion --value=$phpversion


### PR DESCRIPTION
## Problem

Very experimental attempt at fixing https://github.com/YunoHost-Apps/my_webapp_ynh/pull/82

## Solution

To be tested with https://github.com/YunoHost/yunohost/pull/1466

- If the new PHP version is the system default's, then no my-webapp-ynh-deps package is generated by apt helper and this fails
- Weirdly, the `__PHPVERSION__` placeholder in PHP-FPM config is not updated.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
